### PR TITLE
Improve FileLogger default log file root path

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--Version-->
-    <VersionPrefix>0.7.1</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
 
     <!--Metadata-->
     <Authors>romandres</Authors>

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+using Serilog.Templates;
+
+namespace PSStreamLoggerModule
+{
+    [Cmdlet(VerbsCommon.New, "AzureApplicationInsightsLogger")]
+    public class NewAzureApplicationInsightsLogger : PSCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public string? ConnectionString { get; set; }
+
+        [Parameter()]
+        public Hashtable? Properties { get; set; }
+
+        [Parameter()]
+        public string? FilterIncludeOnlyExpression { get; set; }
+
+        [Parameter()]
+        public string? FilterExcludeExpression { get; set; }
+
+        [Parameter()]
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+
+        protected override void EndProcessing()
+        {
+            var loggerConfiguration = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Is(MinimumLogLevel)
+                .WriteTo.ApplicationInsights(
+                     connectionString: ConnectionString,
+                     telemetryConverter: (new AzureApplicationInsightsTraceTelemetryConverter(Properties?.Cast<DictionaryEntry>().ToDictionary(x => x.Key.ToString(), x => x.Value.ToString()))),
+                     restrictedToMinimumLevel: MinimumLogLevel)
+                .Enrich.FromLogContext();
+
+            if (FilterIncludeOnlyExpression is object)
+            {
+                loggerConfiguration = loggerConfiguration
+                    .Filter.ByIncludingOnly(FilterIncludeOnlyExpression);
+            }
+
+            if (FilterExcludeExpression is object)
+            {
+                loggerConfiguration = loggerConfiguration
+                    .Filter.ByExcluding(FilterExcludeExpression);
+            }
+
+            WriteObject(loggerConfiguration.CreateLogger());
+        }
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using System.Management.Automation;
 using Serilog;
 using Serilog.Templates;
@@ -38,10 +39,16 @@ namespace PSStreamLoggerModule
 
         protected override void EndProcessing()
         {
+            string filePath = FilePath!;
+            if (!Path.IsPathRooted(filePath))
+            {
+                filePath = Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, filePath);
+            }
+
             var loggerConfiguration = new Serilog.LoggerConfiguration()
                 .MinimumLevel.Is(MinimumLogLevel)
                 .WriteTo.File(
-                    path: FilePath!,
+                    path: filePath,
                     formatter: new ExpressionTemplate(template: ExpressionTemplate, formatProvider: CultureInfo.CurrentCulture),
                     fileSizeLimitBytes: FileSizeLimit,
                     retainedFileCountLimit: RetainedFileCountLimit,

--- a/src/PSStreamLogger/Logging/AzureApplicationInsightsTraceTelemetryConverter.cs
+++ b/src/PSStreamLogger/Logging/AzureApplicationInsightsTraceTelemetryConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights.Channel;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+
+namespace PSStreamLoggerModule
+{
+    internal class AzureApplicationInsightsTraceTelemetryConverter : TraceTelemetryConverter
+    {
+        private readonly IDictionary<string, string>? properties;
+
+        public AzureApplicationInsightsTraceTelemetryConverter(IDictionary<string, string>? properties)
+        {
+            this.properties = properties;
+        }
+
+        public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            foreach (ITelemetry telemetry in base.Convert(logEvent, formatProvider))
+            {
+                if (properties is object)
+                {
+                    foreach (var property in properties)
+                    {
+                        telemetry.Context.GlobalProperties.Add(property.Key, property.Value);
+                    }
+                }
+
+                yield return telemetry;
+            }
+        }
+    }
+}

--- a/src/PSStreamLogger/PSStreamLogger.csproj
+++ b/src/PSStreamLogger/PSStreamLogger.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -25,7 +25,8 @@
 
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Expressions" Version="3.4.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
 
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/PSStreamLogger/PSStreamLogger.psd1
+++ b/src/PSStreamLogger/PSStreamLogger.psd1
@@ -23,6 +23,7 @@
 
 	CmdletsToExport = @(
 		"Invoke-CommandWithLogging"
+		"New-AzureApplicationInsightsLogger"
 		"New-ConsoleLogger"
 		"New-FileLogger"
 		"New-EventLogLogger"


### PR DESCRIPTION
FileLogger: If log file path (parameter: FilePath) is not rooted, use working directory as the root path.