### PR TITLE
PowerShell Stream Configuration based on lowest Log Level

### DIFF
--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Serilog;
+using Serilog.Events;
 
 namespace PSStreamLoggerModule
 {
@@ -16,11 +17,13 @@ namespace PSStreamLoggerModule
         public ScriptBlock? ScriptBlock { get; set; }
 
         [Parameter(Mandatory = true)]
-        public Serilog.Core.Logger[]? Loggers { get; set; }
+        public Logger[]? Loggers { get; set; }
 
         [Parameter]
-        public SwitchParameter UseSeparateSession { get; set; }
+        public SwitchParameter UseNewRunspace { get; set; }
 
+        private LogEventLevel minimumLogLevel = LogEventLevel.Information;
+        
         private ILoggerFactory? loggerFactory;
 
         private Microsoft.Extensions.Logging.ILogger? scriptLogger;
@@ -49,7 +52,7 @@ namespace PSStreamLoggerModule
                     {
                         foreach (var logger in Loggers)
                         {
-                            logger.Dispose();
+                            logger.SerilogLogger.Dispose();
                         }
                     }
 
@@ -67,12 +70,21 @@ namespace PSStreamLoggerModule
 
         protected override void EndProcessing()
         {
-            Func<Collection<PSObject>> exec;
-            if (!UseSeparateSession.IsPresent)
+            PSDataCollection<PSObject> output = new PSDataCollection<PSObject>();
+
+            Action exec;
+            if (!UseNewRunspace.IsPresent)
             {
+                var streamConfiguration = PowerShellExecutor.GetStreamConfiguration(minimumLogLevel);
+                StringBuilder logLevelCommandBuilder = new StringBuilder();
+                foreach (var streamConfigurationItem in streamConfiguration)
+                {
+                    logLevelCommandBuilder.Append($"${streamConfigurationItem.Key} = \"{streamConfigurationItem.Value}\"; ");
+                }
+
                 exec = () =>
                 {
-                    return InvokeCommand.InvokeScript($"& {{ {ScriptBlock} {Environment.NewLine}}} *>&1 | PSStreamLogger\\Out-PSStreamLogger -DataRecordLogger $input[0]", false, PipelineResultTypes.Output, new List<object>() { dataRecordLogger! });
+                    InvokeCommand.InvokeScript($"{logLevelCommandBuilder} & {{ {ScriptBlock} {Environment.NewLine}}} *>&1 | PSStreamLogger\\Out-PSStreamLogger -DataRecordLogger $input[0]", true, PipelineResultTypes.Output, new List<object>() { dataRecordLogger! });
                 };
             }
             else
@@ -80,17 +92,17 @@ namespace PSStreamLoggerModule
                 // Get current directory (Environment.CurrentDirectory does not work when the current directory was changed after starting the process)
                 var currentPath = InvokeCommand.InvokeScript("Get-Location")[0].BaseObject.ToString();
 
-                powerShellExecutor = new PowerShellExecutor(dataRecordLogger!, currentPath);
+                powerShellExecutor = new PowerShellExecutor(dataRecordLogger!, minimumLogLevel, currentPath);
 
                 exec = () =>
                 {
-                    return powerShellExecutor.Execute(ScriptBlock!.ToString());
+                    powerShellExecutor.Execute(ScriptBlock!.ToString(), output);
                 };
             }
 
             try
             {
-                var output = exec.Invoke();
+                exec.Invoke();
                 WriteObject(output, true);
             }
             catch (RuntimeException ex)
@@ -103,14 +115,20 @@ namespace PSStreamLoggerModule
         private void PrepareLogging()
         {
             loggerFactory = new LoggerFactory();
-
+            
+            minimumLogLevel = Serilog.Events.LogEventLevel.Information;
             foreach (var logger in Loggers!)
             {
-                loggerFactory.AddSerilog(logger);
+                if (logger.MinimumLogLevel < minimumLogLevel)
+                {
+                    minimumLogLevel = logger.MinimumLogLevel;
+                }
+
+                loggerFactory.AddSerilog(logger.SerilogLogger);
             }
 
             scriptLogger = loggerFactory.CreateLogger("PSScriptBlock");
-            dataRecordLogger = new DataRecordLogger(scriptLogger, UseSeparateSession.IsPresent ? 0 : 2);
+            dataRecordLogger = new DataRecordLogger(scriptLogger, UseNewRunspace.IsPresent ? 0 : 2);
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -96,9 +96,7 @@ namespace PSStreamLoggerModule
             }
             else
             {
-                // Get current directory (Environment.CurrentDirectory does not work when the current directory was changed after starting the process)
-                var currentPath = InvokeCommand.InvokeScript("Get-Location")[0].BaseObject.ToString();
-
+                string currentPath = SessionState.Path.CurrentLocation.Path;
                 powerShellExecutor = new PowerShellExecutor(dataRecordLogger!, DisableStreamConfiguration.IsPresent, minimumLogLevel, currentPath);
 
                 exec = () =>

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -1,0 +1,15 @@
+namespace PSStreamLoggerModule
+{
+    public class Logger
+    {
+        public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger)
+        {
+            MinimumLogLevel = minimumLogLevel;
+            SerilogLogger = serilogLogger;
+        }
+        
+        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; set; }
+        
+        public Serilog.Core.Logger SerilogLogger { get; set; }
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -52,7 +52,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -41,7 +41,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -56,7 +56,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -69,7 +69,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
+++ b/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
@@ -14,7 +14,7 @@ namespace PSStreamLoggerModule
 
         private readonly DataRecordLogger dataRecordLogger;
 
-        public PowerShellExecutor(DataRecordLogger dataRecordLogger, Serilog.Events.LogEventLevel minimumLogLevel, string workingDirectory)
+        public PowerShellExecutor(DataRecordLogger dataRecordLogger, bool disableStreamConfiguration, Serilog.Events.LogEventLevel minimumLogLevel, string workingDirectory)
         {
             this.dataRecordLogger = dataRecordLogger;
 
@@ -26,10 +26,13 @@ namespace PSStreamLoggerModule
             powerShell = PowerShell.Create();
             powerShell.Runspace = runspace;
 
-            var streamConfiguration = GetStreamConfiguration(minimumLogLevel);
-            foreach (var streamConfigurationItem in streamConfiguration)
+            if (!disableStreamConfiguration)
             {
-                powerShell.Runspace.SessionStateProxy.SetVariable(streamConfigurationItem.Key, streamConfigurationItem.Value);
+                var streamConfiguration = GetStreamConfiguration(minimumLogLevel);
+                foreach (var streamConfigurationItem in streamConfiguration)
+                {
+                    powerShell.Runspace.SessionStateProxy.SetVariable(streamConfigurationItem.Key, streamConfigurationItem.Value);
+                }
             }
 
             powerShell.Runspace.SessionStateProxy.Path.SetLocation(workingDirectory);

--- a/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
+++ b/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
@@ -52,6 +52,7 @@ namespace PSStreamLoggerModule
                 { "DebugPreference", minimumLogLevel <= LogEventLevel.Debug ? "Continue" : "SilentlyContinue" },
                 { "InformationPreference", minimumLogLevel <= LogEventLevel.Information ? "Continue" : "SilentlyContinue" },
                 { "WarningPreference", minimumLogLevel <= LogEventLevel.Warning ? "Continue" : "SilentlyContinue" },
+                { "ErrorActionPreference", minimumLogLevel <= LogEventLevel.Fatal ? "Continue" : "SilentlyContinue" },
             };
         }
 

--- a/src/PSStreamLogger/PowerShell/RunMode.cs
+++ b/src/PSStreamLogger/PowerShell/RunMode.cs
@@ -1,0 +1,9 @@
+namespace PSStreamLoggerModule
+{
+    public enum RunMode
+    {
+        NewScope,
+        CurrentScope,
+        NewRunspace
+    }
+}


### PR DESCRIPTION
- PowerShell Streams Verbose, Debug, Information, Warning and Error are automatically enabled or disabled based on the lowest log level configured on any logger.
- Allow to freely configure run mode NewScope (new default), CurrentScope (previous default), NewRunspace. This replaces the UseNewScope switch, that was actually badly named and rather would use a new runspace when present.