### PR TITLE
Configuration of run mode

### DIFF
--- a/src/PSStreamLogger/PowerShell/RunMode.cs
+++ b/src/PSStreamLogger/PowerShell/RunMode.cs
@@ -1,0 +1,9 @@
+namespace PSStreamLoggerModule
+{
+    public enum RunMode
+    {
+        NewScope,
+        CurrentScope,
+        NewRunspace
+    }
+}


### PR DESCRIPTION
Allow to configure run mode NewScope (new default), CurrentScope (previous default) and NewRunspace (this replaces the UseNewScope switch, that was actually badly named and rather would use a new runspace when present)