### PR TITLE
PowerShell Stream Configuration based on lowest Log Level

### DIFF
--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -26,7 +26,7 @@ namespace PSStreamLoggerModule
         [Parameter]
         public SwitchParameter DisableStreamConfiguration { get; set; }
 
-        private LogEventLevel minimumLogLevel = LogEventLevel.Information;
+        private LogEventLevel minimumLogLevel;
         
         private ILoggerFactory? loggerFactory;
 

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -75,14 +75,16 @@ namespace PSStreamLoggerModule
         protected override void EndProcessing()
         {
             Func<Collection<PSObject>> exec;
+
+            var streamConfiguration = !DisableStreamConfiguration.IsPresent ? new PSStreamConfiguration(minimumLogLevel) : null;
+
             if (RunMode != RunMode.NewRunspace)
             {
                 StringBuilder logLevelCommandBuilder = new StringBuilder();
                 
-                if (!DisableStreamConfiguration.IsPresent)
+                if (streamConfiguration is object)
                 {
-                    var streamConfiguration = PowerShellExecutor.GetStreamConfiguration(minimumLogLevel);
-                    foreach (var streamConfigurationItem in streamConfiguration)
+                    foreach (var streamConfigurationItem in streamConfiguration.StreamConfiguration)
                     {
                         logLevelCommandBuilder.Append($"${streamConfigurationItem.Key} = \"{streamConfigurationItem.Value}\"; ");
                     }
@@ -96,7 +98,7 @@ namespace PSStreamLoggerModule
             else
             {
                 string currentPath = SessionState.Path.CurrentLocation.Path;
-                powerShellExecutor = new PowerShellExecutor(dataRecordLogger!, DisableStreamConfiguration.IsPresent, minimumLogLevel, currentPath);
+                powerShellExecutor = new PowerShellExecutor(dataRecordLogger!, streamConfiguration, currentPath);
 
                 exec = () =>
                 {

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -1,0 +1,15 @@
+namespace PSStreamLoggerModule
+{
+    public class Logger
+    {
+        public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger)
+        {
+            MinimumLogLevel = minimumLogLevel;
+            SerilogLogger = serilogLogger;
+        }
+        
+        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; set; }
+        
+        public Serilog.Core.Logger SerilogLogger { get; set; }
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -52,7 +52,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -41,7 +41,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -56,7 +56,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -69,7 +69,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/PowerShell/PSStreamConfiguration.cs
+++ b/src/PSStreamLogger/PowerShell/PSStreamConfiguration.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Serilog.Events;
+
+namespace PSStreamLoggerModule
+{
+    public class PSStreamConfiguration
+    {
+        private readonly IDictionary<string, string> streamConfiguration;
+
+        public PSStreamConfiguration(LogEventLevel minimumLogLevel)
+        {
+            streamConfiguration = new Dictionary<string, string>
+            {
+                { "VerbosePreference", minimumLogLevel <= LogEventLevel.Verbose ? "Continue" : "SilentlyContinue" },
+                { "DebugPreference", minimumLogLevel <= LogEventLevel.Debug ? "Continue" : "SilentlyContinue" },
+                { "InformationPreference", minimumLogLevel <= LogEventLevel.Information ? "Continue" : "SilentlyContinue" },
+                { "WarningPreference", minimumLogLevel <= LogEventLevel.Warning ? "Continue" : "SilentlyContinue" },
+                { "ErrorActionPreference", minimumLogLevel <= LogEventLevel.Fatal ? "Continue" : "SilentlyContinue" },
+            };
+        }
+
+        public IDictionary<string, string> StreamConfiguration
+        {
+            get
+            {
+                return streamConfiguration;
+            }
+        }
+    }
+}

--- a/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
+++ b/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
@@ -14,7 +14,7 @@ namespace PSStreamLoggerModule
 
         private readonly DataRecordLogger dataRecordLogger;
 
-        public PowerShellExecutor(DataRecordLogger dataRecordLogger, Serilog.Events.LogEventLevel minimumLogLevel, string workingDirectory)
+        public PowerShellExecutor(DataRecordLogger dataRecordLogger, bool disableStreamConfiguration, Serilog.Events.LogEventLevel minimumLogLevel, string workingDirectory)
         {
             this.dataRecordLogger = dataRecordLogger;
 
@@ -26,10 +26,13 @@ namespace PSStreamLoggerModule
             powerShell = PowerShell.Create();
             powerShell.Runspace = runspace;
 
-            var streamConfiguration = GetStreamConfiguration(minimumLogLevel);
-            foreach (var streamConfigurationItem in streamConfiguration)
+            if (!disableStreamConfiguration)
             {
-                powerShell.Runspace.SessionStateProxy.SetVariable(streamConfigurationItem.Key, streamConfigurationItem.Value);
+                var streamConfiguration = GetStreamConfiguration(minimumLogLevel);
+                foreach (var streamConfigurationItem in streamConfiguration)
+                {
+                    powerShell.Runspace.SessionStateProxy.SetVariable(streamConfigurationItem.Key, streamConfigurationItem.Value);
+                }
             }
 
             powerShell.Runspace.SessionStateProxy.Path.SetLocation(workingDirectory);

--- a/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
+++ b/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
@@ -52,6 +52,7 @@ namespace PSStreamLoggerModule
                 { "DebugPreference", minimumLogLevel <= LogEventLevel.Debug ? "Continue" : "SilentlyContinue" },
                 { "InformationPreference", minimumLogLevel <= LogEventLevel.Information ? "Continue" : "SilentlyContinue" },
                 { "WarningPreference", minimumLogLevel <= LogEventLevel.Warning ? "Continue" : "SilentlyContinue" },
+                { "ErrorActionPreference", minimumLogLevel <= LogEventLevel.Fatal ? "Continue" : "SilentlyContinue" },
             };
         }
 

--- a/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
+++ b/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using Serilog.Events;
@@ -56,11 +57,11 @@ namespace PSStreamLoggerModule
             };
         }
 
-        public void Execute(string script, PSDataCollection<PSObject> output)
+        public Collection<PSObject> Execute(string script)
         {
             powerShell.AddScript(script);
 
-            Execute(output);
+            return Execute();
         }
 
         public void Dispose()
@@ -82,9 +83,9 @@ namespace PSStreamLoggerModule
             }
         }
 
-        private void Execute(PSDataCollection<PSObject> output)
+        private Collection<PSObject> Execute()
         {
-            powerShell.Invoke(null, output);
+            return powerShell.Invoke();
         }
 
         private void Debug_DataAdded(object sender, DataAddedEventArgs e)


### PR DESCRIPTION
PowerShell Streams Verbose, Debug, Information, Warning and Error are automatically enabled or disabled based on the lowest log level configured on any logger.