### PR TITLE
Use Console Logger by default

### DIFF
--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -17,7 +17,7 @@ namespace PSStreamLoggerModule
         [Parameter(Mandatory = true)]
         public ScriptBlock? ScriptBlock { get; set; }
 
-        [Parameter(Mandatory = true)]
+        [Parameter()]
         public Logger[]? Loggers { get; set; }
 
         [Parameter]
@@ -122,7 +122,13 @@ namespace PSStreamLoggerModule
         {
             loggerFactory = new LoggerFactory();
             
-            minimumLogLevel = Serilog.Events.LogEventLevel.Information;
+            minimumLogLevel = Logger.DefaultMinimumLogLevel;
+
+            Loggers ??= new[]
+            {
+                NewConsoleLogger.CreateDefaultLogger()
+            };
+            
             foreach (var logger in Loggers!)
             {
                 if (logger.MinimumLogLevel < minimumLogLevel)

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -1,15 +1,22 @@
+using System;
+using Serilog.Events;
+
 namespace PSStreamLoggerModule
 {
     public class Logger
     {
+        public const LogEventLevel DefaultMinimumLogLevel = LogEventLevel.Information;
+        
+        public static readonly string DefaultExpressionTemplate = $"[{{@t:yyyy-MM-dd HH:mm:ss.fffzz}} {{@l:u3}}] {{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
+        
         public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger)
         {
             MinimumLogLevel = minimumLogLevel;
             SerilogLogger = serilogLogger;
         }
         
-        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; set; }
+        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; private set; }
         
-        public Serilog.Core.Logger SerilogLogger { get; set; }
+        public Serilog.Core.Logger SerilogLogger { get; private set; }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -28,7 +28,7 @@ namespace PSStreamLoggerModule
         public string? FilterExcludeExpression { get; set; }
 
         [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -28,7 +28,7 @@ namespace PSStreamLoggerModule
         public ScriptBlock? EventIdProvider { get; set; }
 
         [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -26,7 +26,7 @@ namespace PSStreamLoggerModule
         public RollingInterval RollingInterval { get; set; } = RollingInterval.Infinite;
 
         [Parameter()]
-        public string ExpressionTemplate { get; set; } = $"[{{@t:yyyy-MM-dd HH:mm:ss.fffzz}} {{@l:u3}}] {{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
+        public string ExpressionTemplate { get; set; } = Logger.DefaultExpressionTemplate;
 
         [Parameter()]
         public string? FilterIncludeOnlyExpression { get; set; }
@@ -35,7 +35,7 @@ namespace PSStreamLoggerModule
         public string? FilterExcludeExpression { get; set; }
 
         [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {


### PR DESCRIPTION
Use console logger with log level Information as default logger if no logger is configured.