### PR TITLE
v0.8.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--Version-->
-    <VersionPrefix>0.7.1</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
 
     <!--Metadata-->
     <Authors>romandres</Authors>

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -77,9 +77,7 @@ namespace PSStreamLoggerModule
             }
             else
             {
-                // Get current directory (Environment.CurrentDirectory does not work when the current directory was changed after starting the process)
-                var currentPath = InvokeCommand.InvokeScript("Get-Location")[0].BaseObject.ToString();
-
+                string currentPath = SessionState.Path.CurrentLocation.Path;
                 powerShellExecutor = new PowerShellExecutor(dataRecordLogger!, currentPath);
 
                 exec = () =>

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -17,7 +17,7 @@ namespace PSStreamLoggerModule
         [Parameter(Mandatory = true)]
         public ScriptBlock? ScriptBlock { get; set; }
 
-        [Parameter(Mandatory = true)]
+        [Parameter()]
         public Logger[]? Loggers { get; set; }
 
         [Parameter]
@@ -122,7 +122,13 @@ namespace PSStreamLoggerModule
         {
             loggerFactory = new LoggerFactory();
             
-            minimumLogLevel = Serilog.Events.LogEventLevel.Information;
+            minimumLogLevel = Logger.DefaultMinimumLogLevel;
+
+            Loggers ??= new[]
+            {
+                NewConsoleLogger.CreateDefaultLogger()
+            };
+            
             foreach (var logger in Loggers!)
             {
                 if (logger.MinimumLogLevel < minimumLogLevel)

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -1,0 +1,15 @@
+namespace PSStreamLoggerModule
+{
+    public class Logger
+    {
+        public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger)
+        {
+            MinimumLogLevel = minimumLogLevel;
+            SerilogLogger = serilogLogger;
+        }
+        
+        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; set; }
+        
+        public Serilog.Core.Logger SerilogLogger { get; set; }
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -1,15 +1,22 @@
+using System;
+using Serilog.Events;
+
 namespace PSStreamLoggerModule
 {
     public class Logger
     {
+        public const LogEventLevel DefaultMinimumLogLevel = LogEventLevel.Information;
+        
+        public static readonly string DefaultExpressionTemplate = $"[{{@t:yyyy-MM-dd HH:mm:ss.fffzz}} {{@l:u3}}] {{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
+        
         public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger)
         {
             MinimumLogLevel = minimumLogLevel;
             SerilogLogger = serilogLogger;
         }
         
-        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; set; }
+        internal Serilog.Events.LogEventLevel MinimumLogLevel { get; private set; }
         
-        public Serilog.Core.Logger SerilogLogger { get; set; }
+        public Serilog.Core.Logger SerilogLogger { get; private set; }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -52,7 +52,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -28,7 +28,7 @@ namespace PSStreamLoggerModule
         public string? FilterExcludeExpression { get; set; }
 
         [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+using Serilog.Templates;
+
+namespace PSStreamLoggerModule
+{
+    [Cmdlet(VerbsCommon.New, "AzureApplicationInsightsLogger")]
+    public class NewAzureApplicationInsightsLogger : PSCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public string? ConnectionString { get; set; }
+
+        [Parameter()]
+        public Hashtable? Properties { get; set; }
+
+        [Parameter()]
+        public string? FilterIncludeOnlyExpression { get; set; }
+
+        [Parameter()]
+        public string? FilterExcludeExpression { get; set; }
+
+        [Parameter()]
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+
+        protected override void EndProcessing()
+        {
+            var loggerConfiguration = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Is(MinimumLogLevel)
+                .WriteTo.ApplicationInsights(
+                     connectionString: ConnectionString,
+                     telemetryConverter: (new AzureApplicationInsightsTraceTelemetryConverter(Properties?.Cast<DictionaryEntry>().ToDictionary(x => x.Key.ToString(), x => x.Value.ToString()))),
+                     restrictedToMinimumLevel: MinimumLogLevel)
+                .Enrich.FromLogContext();
+
+            if (FilterIncludeOnlyExpression is object)
+            {
+                loggerConfiguration = loggerConfiguration
+                    .Filter.ByIncludingOnly(FilterIncludeOnlyExpression);
+            }
+
+            if (FilterExcludeExpression is object)
+            {
+                loggerConfiguration = loggerConfiguration
+                    .Filter.ByExcluding(FilterExcludeExpression);
+            }
+
+            WriteObject(loggerConfiguration.CreateLogger());
+        }
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -41,7 +41,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -56,7 +56,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -28,7 +28,7 @@ namespace PSStreamLoggerModule
         public ScriptBlock? EventIdProvider { get; set; }
 
         [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -26,7 +26,7 @@ namespace PSStreamLoggerModule
         public RollingInterval RollingInterval { get; set; } = RollingInterval.Infinite;
 
         [Parameter()]
-        public string ExpressionTemplate { get; set; } = $"[{{@t:yyyy-MM-dd HH:mm:ss.fffzz}} {{@l:u3}}] {{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
+        public string ExpressionTemplate { get; set; } = Logger.DefaultExpressionTemplate;
 
         [Parameter()]
         public string? FilterIncludeOnlyExpression { get; set; }
@@ -35,7 +35,7 @@ namespace PSStreamLoggerModule
         public string? FilterExcludeExpression { get; set; }
 
         [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Serilog.Events.LogEventLevel.Information;
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using System.Management.Automation;
 using Serilog;
 using Serilog.Templates;
@@ -38,10 +39,16 @@ namespace PSStreamLoggerModule
 
         protected override void EndProcessing()
         {
+            string filePath = FilePath!;
+            if (!Path.IsPathRooted(filePath))
+            {
+                filePath = Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, filePath);
+            }
+
             var loggerConfiguration = new Serilog.LoggerConfiguration()
                 .MinimumLevel.Is(MinimumLogLevel)
                 .WriteTo.File(
-                    path: FilePath!,
+                    path: filePath,
                     formatter: new ExpressionTemplate(template: ExpressionTemplate, formatProvider: CultureInfo.CurrentCulture),
                     fileSizeLimitBytes: FileSizeLimit,
                     retainedFileCountLimit: RetainedFileCountLimit,

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -69,7 +69,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(loggerConfiguration.CreateLogger());
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
     }
 }

--- a/src/PSStreamLogger/Logging/AzureApplicationInsightsTraceTelemetryConverter.cs
+++ b/src/PSStreamLogger/Logging/AzureApplicationInsightsTraceTelemetryConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights.Channel;
+using Serilog.Events;
+using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
+
+namespace PSStreamLoggerModule
+{
+    internal class AzureApplicationInsightsTraceTelemetryConverter : TraceTelemetryConverter
+    {
+        private readonly IDictionary<string, string>? properties;
+
+        public AzureApplicationInsightsTraceTelemetryConverter(IDictionary<string, string>? properties)
+        {
+            this.properties = properties;
+        }
+
+        public override IEnumerable<ITelemetry> Convert(LogEvent logEvent, IFormatProvider formatProvider)
+        {
+            foreach (ITelemetry telemetry in base.Convert(logEvent, formatProvider))
+            {
+                if (properties is object)
+                {
+                    foreach (var property in properties)
+                    {
+                        telemetry.Context.GlobalProperties.Add(property.Key, property.Value);
+                    }
+                }
+
+                yield return telemetry;
+            }
+        }
+    }
+}

--- a/src/PSStreamLogger/PSStreamLogger.csproj
+++ b/src/PSStreamLogger/PSStreamLogger.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -25,7 +25,8 @@
 
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Expressions" Version="3.4.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
 
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/PSStreamLogger/PSStreamLogger.psd1
+++ b/src/PSStreamLogger/PSStreamLogger.psd1
@@ -23,6 +23,7 @@
 
 	CmdletsToExport = @(
 		"Invoke-CommandWithLogging"
+		"New-AzureApplicationInsightsLogger"
 		"New-ConsoleLogger"
 		"New-FileLogger"
 		"New-EventLogLogger"

--- a/src/PSStreamLogger/PowerShell/PSStreamConfiguration.cs
+++ b/src/PSStreamLogger/PowerShell/PSStreamConfiguration.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Serilog.Events;
+
+namespace PSStreamLoggerModule
+{
+    public class PSStreamConfiguration
+    {
+        private readonly IDictionary<string, string> streamConfiguration;
+
+        public PSStreamConfiguration(LogEventLevel minimumLogLevel)
+        {
+            streamConfiguration = new Dictionary<string, string>
+            {
+                { "VerbosePreference", minimumLogLevel <= LogEventLevel.Verbose ? "Continue" : "SilentlyContinue" },
+                { "DebugPreference", minimumLogLevel <= LogEventLevel.Debug ? "Continue" : "SilentlyContinue" },
+                { "InformationPreference", minimumLogLevel <= LogEventLevel.Information ? "Continue" : "SilentlyContinue" },
+                { "WarningPreference", minimumLogLevel <= LogEventLevel.Warning ? "Continue" : "SilentlyContinue" },
+                { "ErrorActionPreference", minimumLogLevel <= LogEventLevel.Fatal ? "Continue" : "SilentlyContinue" },
+            };
+        }
+
+        public IDictionary<string, string> StreamConfiguration
+        {
+            get
+            {
+                return streamConfiguration;
+            }
+        }
+    }
+}

--- a/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
+++ b/src/PSStreamLogger/PowerShell/PowerShellExecutor.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
+using Serilog.Events;
 
 namespace PSStreamLoggerModule
 {
@@ -13,7 +15,7 @@ namespace PSStreamLoggerModule
 
         private readonly DataRecordLogger dataRecordLogger;
 
-        public PowerShellExecutor(DataRecordLogger dataRecordLogger, string workingDirectory)
+        public PowerShellExecutor(DataRecordLogger dataRecordLogger, PSStreamConfiguration? streamConfiguration, string workingDirectory)
         {
             this.dataRecordLogger = dataRecordLogger;
 
@@ -24,6 +26,14 @@ namespace PSStreamLoggerModule
 
             powerShell = PowerShell.Create();
             powerShell.Runspace = runspace;
+
+            if (streamConfiguration is object)
+            {
+                foreach (var streamConfigurationItem in streamConfiguration.StreamConfiguration)
+                {
+                    powerShell.Runspace.SessionStateProxy.SetVariable(streamConfigurationItem.Key, streamConfigurationItem.Value);
+                }
+            }
 
             powerShell.Runspace.SessionStateProxy.Path.SetLocation(workingDirectory);
 

--- a/src/PSStreamLogger/PowerShell/RunMode.cs
+++ b/src/PSStreamLogger/PowerShell/RunMode.cs
@@ -1,0 +1,9 @@
+namespace PSStreamLoggerModule
+{
+    public enum RunMode
+    {
+        NewScope,
+        CurrentScope,
+        NewRunspace
+    }
+}


### PR DESCRIPTION
- Add support for Azure Application Insights as a logger
- Use Console logger by default if no loggers are configured. This is meant to make getting started with this module easier by requiring less configuration by default.

# Breaking changes

- Automatically configure PowerShell Streams based on the lowest minimum log level of all loggers. This behaviour can be disabled by using the new switch parameter `-DisableStreamConfiguration`. This is meant to make getting started with this module easier by requiring less configuration by default.
- The new parameter `-RunMode` replaces the switch parameter `-UseSeparateScope` and allows configuration of the run mode: `CurrentScope` (previous default), `NewScope` (new default) and `NewRunspace` (which was previously achieved by the replaced switch `-UseSeparateScope`, which was badly named). So if you used `-UseSeparateScope`, use `-RunMode NewRunspace` now. If you want to restore the previous default use `-RunMode CurrentScope`.
- The file logger now uses the current directory (at the time of calling `New-FileLogger`) as the root directory if the `FilePath` is not rooted.