### PR TITLE
v0.9.0

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -102,7 +102,9 @@ jobs:
       shell: pwsh
 
     - name: Copy files to artifact directory
-      run: Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.dll-Help.xml", "*.psd1", "*.psm1")
+      run: |
+        Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.psd1", "*.psm1")
+        Copy-Item -Path "./*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
       shell: pwsh
 
     - name: Set module version in manifest

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -102,9 +102,7 @@ jobs:
       shell: pwsh
 
     - name: Copy files to artifact directory
-      run: |
-        Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.psd1", "*.psm1")
-        Copy-Item -Path "../*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
+      run: Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.dll-Help.xml", "*.psd1", "*.psm1")
       shell: pwsh
 
     - name: Set module version in manifest

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Copy files to artifact directory
       run: |
         Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.psd1", "*.psm1")
-        Copy-Item -Path "./*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
+        Copy-Item -Path "../*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
       shell: pwsh
 
     - name: Set module version in manifest

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Copy files to artifact directory
       run: |
         Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.dll-Help.xml", "*.psd1", "*.psm1")
-        Copy-Item -Path "src/PSStreamLogger/bin/Release/net48/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
+        Copy-Item -Path "src/PSStreamLogger/bin/Release/${{ inputs.targetFramework }}/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
       shell: pwsh
 
     - name: Set module version in manifest

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -102,7 +102,7 @@ jobs:
       shell: pwsh
 
     - name: Copy files to artifact directory
-      run: Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.psd1", "*.psm1")
+      run: Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.dll-Help.xml", "*.psd1", "*.psm1")
       shell: pwsh
 
     - name: Set module version in manifest

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -102,7 +102,9 @@ jobs:
       shell: pwsh
 
     - name: Copy files to artifact directory
-      run: Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.dll-Help.xml", "*.psd1", "*.psm1")
+      run: |
+        Copy-Item -Path "publish/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll", "*.dll-Help.xml", "*.psd1", "*.psm1")
+        Copy-Item -Path "src/PSStreamLogger/bin/Release/net48/*" -Destination "../artifact/psstreamlogger" -Include @("*.dll-Help.xml")
       shell: pwsh
 
     - name: Set module version in manifest

--- a/.github/workflows/reusable_publish_release.yml
+++ b/.github/workflows/reusable_publish_release.yml
@@ -38,7 +38,8 @@ jobs:
     - name: Arrange manifest files
       run: |
         Move-Item -Path "./module/coreclr/*" -Destination "./module" -Include @("*.psm1", "*.psd1")
-        Remove-Item -Path "./module/fullclr/*" -Include @("*.psm1", "*.psd1")
+        Move-Item -Path "./module/fullclr/*" -Destination "./module" -Include @("*.dll-Help.xml")
+        Remove-Item -Path "./module/fullclr/*" -Include @("*.psm1", "*.psd1", "*.dll-Help.xml")
       shell: pwsh
 
     - name: Create archive

--- a/.github/workflows/reusable_publish_release.yml
+++ b/.github/workflows/reusable_publish_release.yml
@@ -37,9 +37,8 @@ jobs:
 
     - name: Arrange manifest files
       run: |
-        Move-Item -Path "./module/coreclr/*" -Destination "./module" -Include @("*.psm1", "*.psd1")
-        Move-Item -Path "./module/fullclr/*" -Destination "./module" -Include @("*.dll-Help.xml")
-        Remove-Item -Path "./module/fullclr/*" -Include @("*.psm1", "*.psd1", "*.dll-Help.xml")
+        Move-Item -Path "./module/fullclr/*" -Destination "./module" -Include @("*.psm1", "*.psd1", "*.dll-Help.xml")
+        Remove-Item -Path "./module/coreclr/*" -Include @("*.psm1", "*.psd1", "*.dll-Help.xml")
       shell: pwsh
 
     - name: Create archive

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--Version-->
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
 
     <!--Metadata-->
     <Authors>romandres</Authors>

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -156,7 +156,7 @@ namespace PSStreamLoggerModule
             {
                 if (logger.SerilogLogger is null)
                 {
-                    throw new InvalidOperationException($"Logger was disposed and cannot be reused");
+                    throw new InvalidOperationException($"Logger {logger.Name} was disposed and cannot be reused");
                 }
                 
                 if (logger.MinimumLogLevel < minimumLogLevel)

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -10,19 +10,37 @@ using Serilog.Events;
 
 namespace PSStreamLoggerModule
 {
-
+    /// <summary>
+    /// <para type="synopsis">Executes a command and logs PowerShell stream output.</para>
+    /// <para type="description">Executes a command and sends data written into PowerShell streams (Verbose, Debug, Information, Warning, Error) as log events to the configured loggers.</para>
+    /// <para type="description">Output is passed through to the caller.</para>
+    /// <para type="type">Cmdlet</para>
+    /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke, "CommandWithLogging")]
     public class InvokeCommandWithLoggingCmdlet : PSCmdlet, IDisposable
     {
+        /// <summary>
+        /// <para type="description">The script block to execute.</para>
+        /// </summary>
         [Parameter(Mandatory = true)]
         public ScriptBlock? ScriptBlock { get; set; }
 
+        /// <summary>
+        /// <para type="description">The loggers to send log events to. If no loggers are configured, a console logger with minimum log level information will be used.</para>
+        /// </summary>
         [Parameter()]
         public Logger[]? Loggers { get; set; }
 
+        /// <summary>
+        /// <para type="description">The mode to execute the script block. NewScope executes the script block in a new scope (default), CurrentScope executes it in the current scope (in the same scope this Cmdlet is executed from) and NewRunspace executes it in a new PowerShell runspace.</para>
+        /// </summary>
         [Parameter]
         public RunMode RunMode { get; set; } = RunMode.NewScope;
 
+        /// <summary>
+        /// <para type="description">Disable the automatic PowerShell stream configuration. based on the lowest log level.</para>
+        /// <para type="description">By default the PowerShell streams are configured based on the lowest log level across all loggers.</para>
+        /// </summary>
         [Parameter]
         public SwitchParameter DisableStreamConfiguration { get; set; }
 

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -13,7 +13,7 @@ namespace PSStreamLoggerModule
     /// <summary>
     /// <para type="synopsis">Executes a command and logs PowerShell stream output.</para>
     /// <para type="description">Executes a command and sends data written into PowerShell streams (Verbose, Debug, Information, Warning, Error) as log events to the configured loggers.</para>
-    /// <para type="description">Output is passed through to the caller.</para>
+    /// <para type="description">Output is passed through.</para>
     /// <para type="type">Cmdlet</para>
     /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke, "CommandWithLogging")]

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -32,10 +32,10 @@ namespace PSStreamLoggerModule
         public Logger[]? Loggers { get; set; }
 
         /// <summary>
-        /// <para type="description">The mode to execute the script block. NewScope executes the script block in a new scope (default), CurrentScope executes it in the current scope (in the same scope this Cmdlet is executed from) and NewRunspace executes it in a new PowerShell runspace.</para>
+        /// <para type="description">The mode to execute the script block in. NewScope executes the script block in a new scope (default), CurrentScope executes it in the current scope (in the same scope this Cmdlet is executed from) and NewRunspace executes it in a new PowerShell runspace.</para>
         /// </summary>
         [Parameter]
-        public RunMode RunMode { get; set; } = RunMode.NewScope;
+        public ExecutionMode ExecutionMode { get; set; } = ExecutionMode.NewScope;
 
         /// <summary>
         /// <para type="description">Disable the automatic PowerShell stream configuration. based on the lowest log level.</para>
@@ -96,7 +96,7 @@ namespace PSStreamLoggerModule
 
             var streamConfiguration = !DisableStreamConfiguration.IsPresent ? new PSStreamConfiguration(minimumLogLevel) : null;
 
-            if (RunMode != RunMode.NewRunspace)
+            if (ExecutionMode != ExecutionMode.NewRunspace)
             {
                 StringBuilder logLevelCommandBuilder = new StringBuilder();
                 
@@ -110,7 +110,7 @@ namespace PSStreamLoggerModule
 
                 exec = () =>
                 {
-                    return InvokeCommand.InvokeScript($"{logLevelCommandBuilder}& {{ {ScriptBlock} {Environment.NewLine}}} *>&1 | PSStreamLogger\\Out-PSStreamLogger -DataRecordLogger $input[0]", RunMode == RunMode.NewScope, PipelineResultTypes.Output, new List<object>() { dataRecordLogger! });
+                    return InvokeCommand.InvokeScript($"{logLevelCommandBuilder}& {{ {ScriptBlock} {Environment.NewLine}}} *>&1 | PSStreamLogger\\Out-PSStreamLogger -DataRecordLogger $input[0]", ExecutionMode == ExecutionMode.NewScope, PipelineResultTypes.Output, new List<object>() { dataRecordLogger! });
                 };
             }
             else
@@ -158,7 +158,7 @@ namespace PSStreamLoggerModule
             }
 
             scriptLogger = loggerFactory.CreateLogger("PSScriptBlock");
-            dataRecordLogger = new DataRecordLogger(scriptLogger, RunMode == RunMode.NewRunspace ? 0 : 2);
+            dataRecordLogger = new DataRecordLogger(scriptLogger, ExecutionMode == ExecutionMode.NewRunspace ? 0 : 2);
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/InvokeCommandWithLoggingCmdlet.cs
@@ -74,8 +74,13 @@ namespace PSStreamLoggerModule
                     {
                         foreach (var logger in Loggers)
                         {
-                            logger.SerilogLogger.Dispose();
+                            logger.SerilogLogger?.Dispose();
+                            logger.SerilogLogger = null;
                         }
+                        
+#if DEBUG
+                        Console.WriteLine("DEBUG: Disposed loggers");
+#endif
                     }
 
                     powerShellExecutor?.Dispose();
@@ -149,6 +154,11 @@ namespace PSStreamLoggerModule
             
             foreach (var logger in Loggers!)
             {
+                if (logger.SerilogLogger is null)
+                {
+                    throw new InvalidOperationException($"Logger was disposed and cannot be reused");
+                }
+                
                 if (logger.MinimumLogLevel < minimumLogLevel)
                 {
                     minimumLogLevel = logger.MinimumLogLevel;

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -3,9 +3,6 @@ using Serilog.Events;
 
 namespace PSStreamLoggerModule
 {
-    /// <summary>
-    /// <para type="description">A PSStreamLogger logger.</para>
-    /// </summary>
     public class Logger
     {
         public const LogEventLevel DefaultMinimumLogLevel = LogEventLevel.Information;

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -23,6 +23,6 @@ namespace PSStreamLoggerModule
 
         internal Serilog.Events.LogEventLevel MinimumLogLevel { get; private set; }
         
-        public Serilog.Core.Logger SerilogLogger { get; private set; }
+        internal Serilog.Core.Logger? SerilogLogger { get; set; }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -3,6 +3,9 @@ using Serilog.Events;
 
 namespace PSStreamLoggerModule
 {
+    /// <summary>
+    /// <para type="description">A PSStreamLogger logger.</para>
+    /// </summary>
     public class Logger
     {
         public const LogEventLevel DefaultMinimumLogLevel = LogEventLevel.Information;

--- a/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/Logger.cs
@@ -12,12 +12,15 @@ namespace PSStreamLoggerModule
         
         public static readonly string DefaultExpressionTemplate = $"[{{@t:yyyy-MM-dd HH:mm:ss.fffzz}} {{@l:u3}}] {{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
         
-        public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger)
+        public Logger(Serilog.Events.LogEventLevel minimumLogLevel, Serilog.Core.Logger serilogLogger, string name)
         {
             MinimumLogLevel = minimumLogLevel;
             SerilogLogger = serilogLogger;
+            Name = $"{name}_{Guid.NewGuid()}";
         }
-        
+
+        public string Name { get; private set; }
+
         internal Serilog.Events.LogEventLevel MinimumLogLevel { get; private set; }
         
         public Serilog.Core.Logger SerilogLogger { get; private set; }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -13,22 +13,13 @@ using Serilog.Templates;
 namespace PSStreamLoggerModule
 {
     [Cmdlet(VerbsCommon.New, "AzureApplicationInsightsLogger")]
-    public class NewAzureApplicationInsightsLogger : PSCmdlet
+    public class NewAzureApplicationInsightsLogger : NewLoggerCmdlet
     {
         [Parameter(Mandatory = true)]
         public string? ConnectionString { get; set; }
 
         [Parameter()]
         public Hashtable? Properties { get; set; }
-
-        [Parameter()]
-        public string? FilterIncludeOnlyExpression { get; set; }
-
-        [Parameter()]
-        public string? FilterExcludeExpression { get; set; }
-
-        [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -12,12 +12,23 @@ using Serilog.Templates;
 
 namespace PSStreamLoggerModule
 {
+    /// <summary>
+    /// <para type="synopsis">Creates a new logger that writes log events to an Azure Application Insights instance.</para>
+    /// <para type="description">A logger based on the Serilog.Sinks.ApplicationInsights that writes log events to an Azure Application Insights instance.</para>
+    /// <para type="type">Cmdlet</para>
+    /// </summary>
     [Cmdlet(VerbsCommon.New, "AzureApplicationInsightsLogger")]
     public class NewAzureApplicationInsightsLogger : NewLoggerCmdlet
     {
+        /// <summary>
+        /// <para type="description">The connection string for the target Azure Application Insights instance.</para>
+        /// </summary>
         [Parameter(Mandatory = true)]
         public string? ConnectionString { get; set; }
 
+        /// <summary>
+        /// <para type="description">An optional hashtable containing additional properties to add to each log event (key = log property name, value = log property value).</para>
+        /// </summary>
         [Parameter()]
         public Hashtable? Properties { get; set; }
 

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewAzureApplicationInsightsLogger.cs
@@ -17,9 +17,11 @@ namespace PSStreamLoggerModule
     /// <para type="description">A logger based on the Serilog.Sinks.ApplicationInsights that writes log events to an Azure Application Insights instance.</para>
     /// <para type="type">Cmdlet</para>
     /// </summary>
-    [Cmdlet(VerbsCommon.New, "AzureApplicationInsightsLogger")]
+    [Cmdlet(VerbsCommon.New, Name)]
     public class NewAzureApplicationInsightsLogger : NewLoggerCmdlet
     {
+        private const string Name = "AzureApplicationInsightsLogger";
+        
         /// <summary>
         /// <para type="description">The connection string for the target Azure Application Insights instance.</para>
         /// </summary>
@@ -54,7 +56,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger(), Name));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -7,40 +7,13 @@ using Serilog.Templates;
 namespace PSStreamLoggerModule
 {
     /// <summary>
-    /// <para type="synopsis">Creates a new Console logger.</para>
-    /// <para type="description">Console loggers log to the console.</para>
+    /// <para type="synopsis">Creates a new console logger that writes log events to the console.</para>
+    /// <para type="description">A console logger (based on the Serilog.Sinks.Console) writes log events to the console via standard output.</para>
+    /// <para type="type">Cmdlet</para>
     /// </summary>
     [Cmdlet(VerbsCommon.New, "ConsoleLogger")]
-    public class NewConsoleLogger : PSCmdlet
+    public class NewConsoleLogger : NewTextLoggerCmldet
     {
-        /// <summary>
-        /// <para type="description">This is part of the parameter description.</para>
-        /// <para type="description">This is also part of the parameter description.</para>
-        /// </summary>
-        [Parameter()]
-        public string ExpressionTemplate { get; set; } = Logger.DefaultExpressionTemplate;
-
-        /// <summary>
-        /// <para type="description">This is part of the parameter description.</para>
-        /// <para type="description">This is also part of the parameter description.</para>
-        /// </summary>
-        [Parameter()]
-        public string? FilterIncludeOnlyExpression { get; set; }
-
-        /// <summary>
-        /// <para type="description">This is part of the parameter description.</para>
-        /// <para type="description">This is also part of the parameter description.</para>
-        /// </summary>
-        [Parameter()]
-        public string? FilterExcludeExpression { get; set; }
-
-        /// <summary>
-        /// <para type="description">This is part of the parameter description.</para>
-        /// <para type="description">This is also part of the parameter description.</para>
-        /// </summary>
-        [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
-
         protected override void EndProcessing()
         {
             var loggerConfiguration = CreateLoggerConfiguration(ExpressionTemplate, MinimumLogLevel);

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -11,9 +11,11 @@ namespace PSStreamLoggerModule
     /// <para type="description">A logger based on the Serilog.Sinks.Console that writes log events to the console via standard output.</para>
     /// <para type="type">Cmdlet</para>
     /// </summary>
-    [Cmdlet(VerbsCommon.New, "ConsoleLogger")]
+    [Cmdlet(VerbsCommon.New, Name)]
     public class NewConsoleLogger : NewTextLoggerCmldet
     {
+        private const string Name = "ConsoleLogger";
+        
         protected override void EndProcessing()
         {
             var loggerConfiguration = CreateLoggerConfiguration(ExpressionTemplate, MinimumLogLevel);
@@ -30,7 +32,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger(), Name));
         }
 
         private static LoggerConfiguration CreateLoggerConfiguration(string expressionTemplate, LogEventLevel minimumLogLevel)
@@ -48,7 +50,7 @@ namespace PSStreamLoggerModule
             var minimumLogLevel = Logger.DefaultMinimumLogLevel;
 
             var loggerConfiguration = CreateLoggerConfiguration(Logger.DefaultExpressionTemplate, Logger.DefaultMinimumLogLevel);
-            return new Logger(minimumLogLevel, loggerConfiguration.CreateLogger());
+            return new Logger(minimumLogLevel, loggerConfiguration.CreateLogger(), Name);
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -6,18 +6,38 @@ using Serilog.Templates;
 
 namespace PSStreamLoggerModule
 {
+    /// <summary>
+    /// <para type="synopsis">Creates a new Console logger.</para>
+    /// <para type="description">Console loggers log to the console.</para>
+    /// </summary>
     [Cmdlet(VerbsCommon.New, "ConsoleLogger")]
     public class NewConsoleLogger : PSCmdlet
     {
+        /// <summary>
+        /// <para type="description">This is part of the parameter description.</para>
+        /// <para type="description">This is also part of the parameter description.</para>
+        /// </summary>
         [Parameter()]
         public string ExpressionTemplate { get; set; } = Logger.DefaultExpressionTemplate;
 
+        /// <summary>
+        /// <para type="description">This is part of the parameter description.</para>
+        /// <para type="description">This is also part of the parameter description.</para>
+        /// </summary>
         [Parameter()]
         public string? FilterIncludeOnlyExpression { get; set; }
 
+        /// <summary>
+        /// <para type="description">This is part of the parameter description.</para>
+        /// <para type="description">This is also part of the parameter description.</para>
+        /// </summary>
         [Parameter()]
         public string? FilterExcludeExpression { get; set; }
 
+        /// <summary>
+        /// <para type="description">This is part of the parameter description.</para>
+        /// <para type="description">This is also part of the parameter description.</para>
+        /// </summary>
         [Parameter()]
         public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -8,7 +8,7 @@ namespace PSStreamLoggerModule
 {
     /// <summary>
     /// <para type="synopsis">Creates a new console logger that writes log events to the console.</para>
-    /// <para type="description">A console logger (based on the Serilog.Sinks.Console) writes log events to the console via standard output.</para>
+    /// <para type="description">A logger based on the Serilog.Sinks.Console that writes log events to the console via standard output.</para>
     /// <para type="type">Cmdlet</para>
     /// </summary>
     [Cmdlet(VerbsCommon.New, "ConsoleLogger")]

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewConsoleLogger.cs
@@ -33,7 +33,7 @@ namespace PSStreamLoggerModule
             WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
         }
 
-        public static LoggerConfiguration CreateLoggerConfiguration(string expressionTemplate, LogEventLevel minimumLogLevel)
+        private static LoggerConfiguration CreateLoggerConfiguration(string expressionTemplate, LogEventLevel minimumLogLevel)
         {
             return new Serilog.LoggerConfiguration()
                 .MinimumLevel.Is(minimumLogLevel)
@@ -43,7 +43,7 @@ namespace PSStreamLoggerModule
                 .Enrich.FromLogContext();
         }
         
-        public static Logger CreateDefaultLogger()
+        internal static Logger CreateDefaultLogger()
         {
             var minimumLogLevel = Logger.DefaultMinimumLogLevel;
 

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -7,29 +7,22 @@ using Serilog.Templates;
 namespace PSStreamLoggerModule
 {
     [Cmdlet(VerbsCommon.New, "EventLogLogger")]
-    public class NewEventLogLogger : PSCmdlet
+    public class NewEventLogLogger : NewTextLoggerCmldet
     {
+        public NewEventLogLogger()
+        {
+            ExpressionTemplate = $"{{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
+        }
+        
         [Parameter(Mandatory = true)]
         public string? LogSource { get; set; }
 
         [Parameter()]
         public string? LogName { get; set; }
-
-        [Parameter()]
-        public string ExpressionTemplate { get; set; } = $"{{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
-
-        [Parameter()]
-        public string? FilterIncludeOnlyExpression { get; set; }
-
-        [Parameter()]
-        public string? FilterExcludeExpression { get; set; }
-
+        
         [Parameter()]
         public ScriptBlock? EventIdProvider { get; set; }
-
-        [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
-
+        
         protected override void EndProcessing()
         {
             var loggerConfiguration = new Serilog.LoggerConfiguration()

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -6,6 +6,11 @@ using Serilog.Templates;
 
 namespace PSStreamLoggerModule
 {
+    /// <summary>
+    /// <para type="synopsis">Creates a new event log logger that writes log events to a Windows EventLog.</para>
+    /// <para type="description">A logger based on the Serilog.Sinks.EventLog that writes log events to a Windows EventLog.</para>
+    /// <para type="type">Cmdlet</para>
+    /// </summary>
     [Cmdlet(VerbsCommon.New, "EventLogLogger")]
     public class NewEventLogLogger : NewTextLoggerCmldet
     {
@@ -14,12 +19,23 @@ namespace PSStreamLoggerModule
             ExpressionTemplate = $"{{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
         }
         
+        /// <summary>
+        /// <para type="description">The event source that is typically name of the application/program writing log events to the event log.</para>
+        /// <para type="description">The logger will not create the event source. The event source has to exist for the logger to work (can be created with elevated privileges using New-EventLog).</para>
+        /// </summary>
         [Parameter(Mandatory = true)]
-        public string? LogSource { get; set; }
+        public string? Source { get; set; }
 
+        /// <summary>
+        /// <para type="description">The name of the target event log to which log events are written.</para>
+        /// <para type="description">The logger will not create the event log. The event log has to exist for the logger to work (can be created with elevated privileges using New-EventLog).</para>
+        /// </summary>
         [Parameter()]
         public string? LogName { get; set; }
         
+        /// <summary>
+        /// <para type="description">A script block that provides the event ID for each log event based on the log event's properties.</para>
+        /// </summary>
         [Parameter()]
         public ScriptBlock? EventIdProvider { get; set; }
         
@@ -28,7 +44,7 @@ namespace PSStreamLoggerModule
             var loggerConfiguration = new Serilog.LoggerConfiguration()
                 .MinimumLevel.Is(MinimumLogLevel)
                 .WriteTo.EventLog(
-                    source: LogSource,
+                    source: Source,
                     logName: LogName,
                     formatter: new ExpressionTemplate(template: ExpressionTemplate, formatProvider: CultureInfo.CurrentCulture),
                     restrictedToMinimumLevel: MinimumLogLevel,

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewEventLogLogger.cs
@@ -11,9 +11,11 @@ namespace PSStreamLoggerModule
     /// <para type="description">A logger based on the Serilog.Sinks.EventLog that writes log events to a Windows EventLog.</para>
     /// <para type="type">Cmdlet</para>
     /// </summary>
-    [Cmdlet(VerbsCommon.New, "EventLogLogger")]
+    [Cmdlet(VerbsCommon.New, Name)]
     public class NewEventLogLogger : NewTextLoggerCmldet
     {
+        private const string Name = "EventLogLogger";
+        
         public NewEventLogLogger()
         {
             ExpressionTemplate = $"{{@m:lj}}{Environment.NewLine}{{{DataRecordLogger.PSErrorDetailsKey}}}";
@@ -65,7 +67,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger(), Name));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -26,7 +26,7 @@ namespace PSStreamLoggerModule
         /// <para type="description">The file size limit in bytes (default = 1GB).</para>
         /// </summary>
         [Parameter()]
-        public int? FileSizeLimit { get; set; } = 1073741824; // 1GB
+        public long? FileSizeLimit { get; set; } = 1073741824; // 1GB
 
         /// <summary>
         /// <para type="description">The maximum number of log files to keep if rolling file is used. Older log files will automatically be cleaned up.</para>

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -16,8 +16,8 @@ namespace PSStreamLoggerModule
     public class NewFileLogger : NewTextLoggerCmldet
     {
         /// <summary>
-        /// <para type="description">The log file path.</para>
-        /// <para type="description">For relative paths the current working directory will be used as root path.</para>
+        /// <para type="description">The log file path (absolute or relative).</para>
+        /// <para type="description">For relative paths the current working directory will be used as the root path.</para>
         /// </summary>
         [Parameter(Mandatory = true)]
         public string? FilePath { get; set; }
@@ -41,8 +41,8 @@ namespace PSStreamLoggerModule
         public SwitchParameter RollOnFileSizeLimit { get; set; }
 
         /// <summary>
-        /// <para type="description">The rolling time interval to use.</para>
-        /// <para type="description">Infinite = File will not roll (no new log file will be created) on a time interval.</para>
+        /// <para type="description">The rolling time-based interval to use for the log file.</para>
+        /// <para type="description">Infinite = File will not roll (no new log file will be created) on a time-based interval.</para>
         /// </summary>
         [Parameter()]
         public RollingInterval RollingInterval { get; set; } = RollingInterval.Infinite;

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -8,7 +8,7 @@ using Serilog.Templates;
 namespace PSStreamLoggerModule
 {
     [Cmdlet(VerbsCommon.New, "FileLogger")]
-    public class NewFileLogger : PSCmdlet
+    public class NewFileLogger : NewTextLoggerCmldet
     {
         [Parameter(Mandatory = true)]
         public string? FilePath { get; set; }
@@ -24,18 +24,6 @@ namespace PSStreamLoggerModule
 
         [Parameter()]
         public RollingInterval RollingInterval { get; set; } = RollingInterval.Infinite;
-
-        [Parameter()]
-        public string ExpressionTemplate { get; set; } = Logger.DefaultExpressionTemplate;
-
-        [Parameter()]
-        public string? FilterIncludeOnlyExpression { get; set; }
-
-        [Parameter()]
-        public string? FilterExcludeExpression { get; set; }
-
-        [Parameter()]
-        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
 
         protected override void EndProcessing()
         {

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -7,21 +7,43 @@ using Serilog.Templates;
 
 namespace PSStreamLoggerModule
 {
+    /// <summary>
+    /// <para type="synopsis">Creates a new file logger that writes log events to plain text files.</para>
+    /// <para type="description">A logger based on the Serilog.Sinks.File that writes log events to plain text files.</para>
+    /// <para type="type">Cmdlet</para>
+    /// </summary>
     [Cmdlet(VerbsCommon.New, "FileLogger")]
     public class NewFileLogger : NewTextLoggerCmldet
     {
+        /// <summary>
+        /// <para type="description">The log file path.</para>
+        /// <para type="description">For relative paths the current working directory will be used as root path.</para>
+        /// </summary>
         [Parameter(Mandatory = true)]
         public string? FilePath { get; set; }
 
+        /// <summary>
+        /// <para type="description">The file size limit in bytes (default = 1GB).</para>
+        /// </summary>
         [Parameter()]
         public int? FileSizeLimit { get; set; } = 1073741824; // 1GB
 
+        /// <summary>
+        /// <para type="description">The maximum number of log files to keep if rolling file is used. Older log files will automatically be cleaned up.</para>
+        /// </summary>
         [Parameter()]
         public int? RetainedFileCountLimit { get; set; } = 31;
 
+        /// <summary>
+        /// <para type="description">Whether or not to create a new log file when the file size limit is reached.</para>
+        /// </summary>
         [Parameter()]
         public SwitchParameter RollOnFileSizeLimit { get; set; }
 
+        /// <summary>
+        /// <para type="description">The rolling time interval to use.</para>
+        /// <para type="description">Infinite = File will not roll (no new log file will be created) on a time interval.</para>
+        /// </summary>
         [Parameter()]
         public RollingInterval RollingInterval { get; set; } = RollingInterval.Infinite;
 

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewFileLogger.cs
@@ -12,9 +12,11 @@ namespace PSStreamLoggerModule
     /// <para type="description">A logger based on the Serilog.Sinks.File that writes log events to plain text files.</para>
     /// <para type="type">Cmdlet</para>
     /// </summary>
-    [Cmdlet(VerbsCommon.New, "FileLogger")]
+    [Cmdlet(VerbsCommon.New, Name)]
     public class NewFileLogger : NewTextLoggerCmldet
     {
+        private const string Name = "FileLogger";
+        
         /// <summary>
         /// <para type="description">The log file path (absolute or relative).</para>
         /// <para type="description">For relative paths the current working directory will be used as the root path.</para>
@@ -79,7 +81,7 @@ namespace PSStreamLoggerModule
                     .Filter.ByExcluding(FilterExcludeExpression);
             }
 
-            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger()));
+            WriteObject(new Logger(MinimumLogLevel, loggerConfiguration.CreateLogger(), Name));
         }
     }
 }

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewLoggerCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewLoggerCmdlet.cs
@@ -1,0 +1,29 @@
+using System.Management.Automation;
+
+namespace PSStreamLoggerModule
+{
+    [OutputType(typeof(Logger))]
+    public class NewLoggerCmdlet : PSCmdlet
+    {
+        /// <summary>
+        /// <para type="description">The minimum log level this logger should include.</para>
+        /// <para type="description">Possible values ordered by lowest to highest: Verbose, Debug, Information, Warning, Error, Fatal.</para>
+        /// </summary>
+        [Parameter()]
+        public Serilog.Events.LogEventLevel MinimumLogLevel { get; set; } = Logger.DefaultMinimumLogLevel;
+        
+        /// <summary>
+        /// <para type="description">An expression-based filter (Serilog.Expressions) that defines which log events this logger should include.</para>
+        /// <para type="description">For more information and examples go to: https://github.com/serilog/serilog-expressions#filtering-example.</para>
+        /// </summary>
+        [Parameter()]
+        public string? FilterIncludeOnlyExpression { get; set; }
+
+        /// <summary>
+        /// <para type="description">An expression-based filter (Serilog.Expressions) that defines which log events this logger should exclude.</para>
+        /// <para type="description">For more information and examples go to: https://github.com/serilog/serilog-expressions#filtering-example.</para>
+        /// </summary>
+        [Parameter()]
+        public string? FilterExcludeExpression { get; set; }
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/Loggers/NewTextLoggerCmldet.cs
+++ b/src/PSStreamLogger/Cmdlets/Loggers/NewTextLoggerCmldet.cs
@@ -1,0 +1,15 @@
+using System.Management.Automation;
+
+namespace PSStreamLoggerModule
+{
+    public class NewTextLoggerCmldet : NewLoggerCmdlet
+    {
+        /// <summary>
+        /// <para type="description">The expression template (Serilog.Expressions) defines how log events are converted to text.</para>
+        /// <para type="description">For more information and examples go to: https://github.com/serilog/serilog-expressions#formatting-with-expressiontemplate.</para>
+        /// <para type="description">More examples: https://nblumhardt.com/2021/06/customize-serilog-text-output/</para>
+        /// </summary>
+        [Parameter()]
+        public string ExpressionTemplate { get; set; } = Logger.DefaultExpressionTemplate;
+    }
+}

--- a/src/PSStreamLogger/Cmdlets/OutPSStreamLoggerCmdlet.cs
+++ b/src/PSStreamLogger/Cmdlets/OutPSStreamLoggerCmdlet.cs
@@ -2,12 +2,25 @@
 
 namespace PSStreamLoggerModule
 {
+    /// <summary>
+    /// <para type="synopsis">Sends redirected stream data to the DataRecordLogger.</para>
+    /// <para type="description">This is internally used by the Invoke-CommandWithLogging command if one of the execution modes NewScope or CurrentScope are used to leverage stream redirection to send stream data to the DataRecordLogger through this command.</para>
+    /// <para type="description">Output is passed through.</para>
+    /// <para type="type">Cmdlet</para>
+    /// </summary>
     [Cmdlet(VerbsData.Out, "PSStreamLogger")]
     public class OutPSStreamLoggerCmdlet : PSCmdlet
     {
+        /// <summary>
+        /// <para type="description">PSObject to send to the DataRecordLogger.</para>
+        /// </summary>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         public PSObject? InputObject { get; set; }
 
+        /// <summary>
+        /// <para type="description">The DataRecordLogger that will process PSObjects received.</para>
+        /// <para type="description">PSObjects of type Verbose-, Debug-, Information-, Warning- and ErrorRecord will be processed as log events by the DataRecordLogger while any other object will be passed through.</para>
+        /// </summary>
         [Parameter(Mandatory = true)]
         public DataRecordLogger? DataRecordLogger { get; set; }
 

--- a/src/PSStreamLogger/PSStreamLogger.csproj
+++ b/src/PSStreamLogger/PSStreamLogger.csproj
@@ -11,6 +11,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PSStreamLogger/PSStreamLogger.csproj
+++ b/src/PSStreamLogger/PSStreamLogger.csproj
@@ -9,6 +9,8 @@
     <Nullable>enable</Nullable>
 
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,10 +29,16 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
-
     <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <PackageReference Include="XmlDoc2CmdletDoc" Version="0.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/src/PSStreamLogger/PowerShell/ExecutionMode.cs
+++ b/src/PSStreamLogger/PowerShell/ExecutionMode.cs
@@ -1,6 +1,6 @@
 namespace PSStreamLoggerModule
 {
-    public enum RunMode
+    public enum ExecutionMode
     {
         NewScope,
         CurrentScope,

--- a/src/PSStreamLogger/Properties/launchSettings.json
+++ b/src/PSStreamLogger/Properties/launchSettings.json
@@ -3,12 +3,12 @@
     "PowerShell": {
       "commandName": "Executable",
       "executablePath": "pwsh",
-      "commandLineArgs": "-NoExit -Command \"& { Import-Module .\\PSStreamLogger.psd1 }\""
+      "commandLineArgs": "-NoExit -Command \"& { Import-Module .\\PSStreamLogger.dll }\""
     },
     "Windows PowerShell": {
       "commandName": "Executable",
       "executablePath": "powershell",
-      "commandLineArgs": "-NoExit -Command \"& { Import-Module .\\PSStreamLogger.psd1 }\""
+      "commandLineArgs": "-NoExit -Command \"& { Import-Module .\\PSStreamLogger.dll }\""
     }
   }
 }


### PR DESCRIPTION
- Added PSHelp to all Cmdlets.
- Reusing disposed loggers now causes an exception instead of just not logging anything.
- Fixed debugging launch settings (development)

# Breaking changes

- Improved naming of parameter `RunMode` of Cmdlet `Invoke-CommandWithLogging` and renamed it to: `ExecutionMode`.
- Improved naming of parameter `LogSource` of Cmdlet `New-EventLogLogger` and renamed it to `Source` to align the naming with other EventLog Cmdlets.